### PR TITLE
Need to hardcode Ethernet header type

### DIFF
--- a/cmd/listen.go
+++ b/cmd/listen.go
@@ -231,7 +231,7 @@ func (l *Listen) sendPacket(sndpkt Send) {
 			BaseLayer:    layers.BaseLayer{},
 			DstMAC:       net.HardwareAddr{0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
 			SrcMAC:       l.iface.HardwareAddr,
-			EthernetType: eth.EthernetType,
+			EthernetType: layers.EthernetTypeIPv4,
 		}
 		if err := new_eth.SerializeTo(buffer, opts); err != nil {
 			log.Fatalf("can't serialize Eth header: %v", new_eth)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 )
 
-const Version = "0.0.1"
+const Version = "0.0.2"
 
 func main() {
 	var listen = []string{}


### PR DESCRIPTION
When reading a packet from a Loop interface, the eth.EthernetType is 0