### PR TITLE
learn client IPs on non-broadcast interfaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GOARCH ?= $(shell uname -m)
 BUILDINFOSDET ?=
 UDP_PROXY_2020_ARGS ?=
 
-PROJECT_VERSION    := 0.0.3
+PROJECT_VERSION    := 0.0.4
 DOCKER_REPO        := synfinatic
 PROJECT_NAME       := udp-proxy-2020
 PROJECT_TAG        := $(shell git describe --tags 2>/dev/null $(git rev-list --tags --max-count=1))
@@ -79,7 +79,7 @@ fmt: ## Format Go code
 	@go fmt cmd
 
 .PHONY: test-fmt
-test-fmt: fmt
+test-fmt: fmt ## Test to make sure code if formatted correctly
 	@if test `git diff cmd | wc -l` -gt 0; then \
 	    echo "Code changes detected when running 'go fmt':" ; \
 	    git diff -Xfiles ; \
@@ -87,13 +87,14 @@ test-fmt: fmt
 	fi
 
 .PHONY: test-tidy
-test-tidy:
+test-tidy:  ## Test to make sure go.mod is tidy
 	@go mod tidy
 	@if test `git diff go.mod | wc -l` -gt 0; then \
 	    echo "Need to run 'go mod tidy' to clean up go.mod" ; \
 	    exit -1 ; \
 	fi
 
+precheck: test test-fmt test-tidy  ## Run all tests that happen in a PR
 
 ######################################################################
 # Docker targets for testing

--- a/README.md
+++ b/README.md
@@ -78,3 +78,10 @@ udp-proxy-2020 is still under heavy development.  Run `udp-proxy-2020 --help`
 for a current list of command line options.  Also, please note on many operating
 systems you will need to run it as the `root` user.  Linux systems can
 optionally grant the `CAP_NET_RAW` capability.
+
+Currently there are only a few flags you probaly need to worry about:
+
+ * `--interface` -- specify two or more network interfaces to listen on 
+ * `--port` -- specify one or more UDP ports to monitor
+
+There are other flags of course, run `./udp-proxy-2020 --help` for a full list.

--- a/cmd/interfaces.go
+++ b/cmd/interfaces.go
@@ -50,8 +50,9 @@ func initializeInterface(l *Listen) {
 	}
 
 	// set our BPF filter
-	log.Debugf("%s: applying BPF Filter: %s", l.iname, l.filter)
-	err = l.handle.SetBPFFilter(l.filter)
+	bpf_filter := buildBPFFilter(l.ports)
+	log.Debugf("%s: applying BPF Filter: %s", l.iname, bpf_filter)
+	err = l.handle.SetBPFFilter(bpf_filter)
 	if err != nil {
 		log.Fatalf("%s: %s", l.iname, err)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
+	"net"
 	"os"
-	"os/user"
 	"sync"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	flag "github.com/spf13/pflag"
@@ -19,26 +20,27 @@ func main() {
 	var interfaces = []string{}
 	var ports = []int32{}
 	var timeout int64
+	var cachettl int64
 	var debug bool
 	var version bool
 	var ilist bool
 
 	// option parsing
-
-	flag.StringSliceVar(&interfaces, "interface", []string{}, "interfaces to use")
-	flag.Int32SliceVar(&ports, "port", []int32{}, "one or more UDP ports to process")
-	flag.Int64Var(&timeout, "timeout", 250, "timeout in ms")
+	flag.StringSliceVar(&interfaces, "interface", []string{}, "Two or more interfaces to use")
+	flag.Int32SliceVar(&ports, "port", []int32{}, "One or more UDP ports to process")
+	flag.Int64Var(&timeout, "timeout", 250, "Timeout in ms")
+	flag.Int64Var(&cachettl, "cachettl", 90, "Client IP cache TTL in sec")
 	flag.BoolVar(&debug, "debug", false, "Enable debugging")
 	flag.BoolVar(&ilist, "list-interfaces", false, "List available interfaces and exit")
 	flag.BoolVar(&version, "version", false, "Print version and exit")
 
 	flag.Parse()
 
-	log.SetReportCaller(true)
-	// log.DisableLevelTruncation(true)
+	// log.DisableLevelTruncation(true) <-- supposed to work, but doesn't?
 
 	// turn on debugging?
 	if debug == true {
+		log.SetReportCaller(true)
 		log.SetLevel(log.DebugLevel)
 	} else {
 		log.SetLevel(log.WarnLevel)
@@ -55,28 +57,38 @@ func main() {
 		os.Exit(0)
 	}
 
-	// make sure we're root
-	if u, err := user.Current(); err != nil {
-		log.Fatal(err)
-	} else if u.Uid != "0" {
-		log.Fatal("need to run as root in order for raw sockets to work")
-	}
-
 	// Neeed at least two interfaces
 	if len(interfaces) < 2 {
-		log.Fatal("Please specify --interfaces at least twice")
+		log.Fatal("Please specify two or more interfaces via --interface")
 	}
 
-	// handle our timeout & bpf filter for ports
+	// handle our timeout
 	to := parseTimeout(timeout)
-	bpf_filter := buildBPFFilter(ports)
 
-	// init the listeners
-	listeners := initializeListeners(interfaces, bpf_filter, ports, to)
+	// create our Listeners
+	var seenInterfaces = []string{}
+	var listeners = []Listen{}
+	for _, iface := range interfaces {
+		// check for duplicates
+		if stringPrefixInSlice(iface, seenInterfaces) {
+			log.Fatalf("Can't specify the same interface (%s) multiple times", iface)
+		}
+		seenInterfaces = append(seenInterfaces, iface)
+
+		netif, err := net.InterfaceByName(iface)
+		if err != nil {
+			log.Fatalf("Unable to find interface: %s: %s", iface, err)
+		}
+
+		var promisc bool = (netif.Flags & net.FlagBroadcast) == 0
+		listeners = append(listeners, newListener(netif, promisc, ports, to))
+	}
 
 	// init each listener
+	ttl, _ := time.ParseDuration(fmt.Sprintf("%ds", cachettl))
 	for i := range listeners {
 		initializeInterface(&listeners[i])
+		listeners[i].clientTTL = ttl
 		defer listeners[i].handle.Close()
 	}
 


### PR DESCRIPTION
Everytime we receieve a packet, cache that source IP for later
We then use this cache to send packets out on loopback/etc
interfaces which don't support broadcast so replies are
automatically sent to clients on OpenVPN tunnels, etc.

add `make precheck` test which runs all the tests in the PR

bump version to 0.0.4

Fixes: #6, #5