### PR TITLE
Initial hack for site-to-site OpenVPN tunnels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## Unreleased
 
+## v0.0.6 - ??-??-2020
+
 Added:
-- Support for cross-compiling arm64/Linux for RasPi #31
+- Support for cross-compiling arm64/Linux for RasPi/Ubiquiti UDM(Pro) #31
+- Support Site-to-Site OpenVPN tunnels via --fixed-ip #41
 
 Fixed:
 - Vagrant file for FreeBSD now always builds the latest code #39

--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ Currently there are only a few flags you probaly need to worry about:
 
  * `--interface` -- specify two or more network interfaces to listen on
  * `--port` -- specify one or more UDP ports to monitor
+ * `--debug` -- enable debugging output
+ * `--fixed-ip` -- Hardcode an <interface>@<ipaddr> to always send traffic to.  Useful
+	for things like OpenVPN in site-to-site mode.
 
 There are other flags of course, run `./udp-proxy-2020 --help` for a full list.
 
@@ -104,7 +107,7 @@ that came to my mind.
 ### What network interface types are supported?
 
  * Ethernet
- * WiFi interfaces which appear as Ethernet 
+ * WiFi interfaces which appear as Ethernet
  * `tun` interfaces, like those used by [OpenVPN](https://openvpn.net)
  * `raw` interfaces, like those used by [Wireguard](https://www.wireguard.com)
 


### PR DESCRIPTION
OpenVPN is still using a PointToPoint tunnel, but since the Roon
client is not running on the VPN tunnel endpoint we can't rely
on Roon automatically sending on the tunnel interface on the
client end.

This is a ugly hack though because it relies on the user to
hard code the RoonCore side VPN tunnel IP on the client which
is really annoying :-/

Refs: #41