### PR TITLE
Fix typo for UDM startup script

### DIFF
--- a/startup-scripts/udm-utilities/on_boot.d/40-udp-proxy-2020.sh
+++ b/startup-scripts/udm-utilities/on_boot.d/40-udp-proxy-2020.sh
@@ -11,7 +11,7 @@ if [ -z "$PORTS" ]; then
     exit 1
 fi
 
-if [ -z "$INTEFACES" ]; then
+if [ -z "$INTERFACES" ]; then
     echo "Error: 'INTERFACES' is not set in config file" >/dev/stderr
     exit 1
 fi


### PR DESCRIPTION
The typo should definitely be fixed, but I'm not entirely sure about the Dockerfiles. I figured that we didn't need them, so I'd go ahead and remove them. If we still need them, then I can submit a PR with just the typo fix.