### PR TITLE
Actively listen on UDP ports to avoid sending ICMP Port Unreachable

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -16,12 +16,17 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - name: Set Env Vars
+        run: |
+          echo "GOARCH=amd64" >> $GITHUB_ENV
+      - name: Install deps
+        run: sudo apt-get update && sudo apt-get install -y libpcap0.8 libpcap0.8-dev
       - uses: actions/checkout@v2
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.43.0
+          version: v1.45.2
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,21 @@
 
 ## Unreleased
 
+## v0.0.11 - 2022-04-14
+
+Added:
+ - Now listens on the interfaces/port(s) so that the
+    underlying operating system will not generate ICMP Port Unreachables
+    which fixes Roon on iPhone/etc over VPN. #86
+
+Fixed:
+ - Update golangci-lint to fix linter build errors 
+
 ## v0.0.10 - 2022-03-18
 
 Fixed:
  - Docker container would not start.
+
 
 ## v0.0.9 - 2022-02-21
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GOARCH ?= $(shell uname -m | sed -E 's/x86_64/amd64/')
 BUILDINFOSDET ?=
 UDP_PROXY_2020_ARGS ?=
 
-PROJECT_VERSION    := 0.0.10
+PROJECT_VERSION    := 0.0.11
 DOCKER_REPO        := synfinatic
 PROJECT_NAME       := udp-proxy-2020
 PROJECT_TAG        := $(shell git describe --tags 2>/dev/null $(git rev-list --tags --max-count=1))

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -159,6 +159,13 @@ func main() {
 		defer listeners[i].handle.Close()
 	}
 
+	// Sink broadcast messages
+	for _, l := range listeners {
+		if err := l.SinkUdpPackets(); err != nil {
+			log.WithError(err).Fatalf("Unable to init SinkUdpPackets")
+		}
+	}
+
 	// start handling packets
 	var wg sync.WaitGroup
 	spf := SendPktFeed{}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/google/gopacket v1.1.18
 	github.com/sirupsen/logrus v1.8.1
-	// see: https://github.com/sirupsen/logrus/issues/1275
-	golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2 // indirect
 )
+
+// see: https://github.com/sirupsen/logrus/issues/1275
+require golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2 // indirect


### PR DESCRIPTION
We now create a UDP socket listener for the UDP port(s) on all the
active interfaces so that the underlying OS does not geneate ICMP Port
Unreachable messages which cause problems with certain clients like
those written in .Net.

Fixes issues with Roon over VPN tunnels

Fixes: 86