### PR TITLE
Add support for building RPM/DEB packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+Added:
+ - Create Debian & RPM packages for x86 and ARM64
+
 ## v0.0.11 - 2022-04-14
 
 Added:

--- a/Dockerfile.package
+++ b/Dockerfile.package
@@ -1,0 +1,14 @@
+FROM ubuntu:20.04 AS base
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y git golang && apt-get clean
+RUN mkdir -p /root/dist && \
+    cd /root && git clone https://github.com/kentik/pkg.git && \
+    cd pkg && go build . && mv pkg /usr/bin/pkg
+
+FROM base as builder
+ENV VERSION=1.0.0
+RUN mkdir -p /root/startup-scripts/systemd /root/package
+COPY package.sh /root
+COPY startup-scripts/systemd/* /root/startup-scripts/systemd/
+COPY package/* /root/package/
+CMD /root/package.sh

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ release: build-release ## Build and sign official release
 	cd dist && shasum -a 256 udp-proxy-2020* | gpg --clear-sign >release.sig
 	@echo "Now run `make docker-release`?"
 
-build-release: clean linux-amd64 linux-mips64 linux-arm darwin-amd64 freebsd docker ## Build our release binaries
+build-release: clean linux-amd64 linux-mips64 linux-arm darwin-amd64 freebsd docker package ## Build our release binaries
 
 tags: cmd/*.go  ## Create tags file for vim, etc
 	@echo Make sure you have Universal Ctags installed: https://github.com/universal-ctags/ctags
@@ -350,3 +350,9 @@ docker-release: ## Tag and push docker images Linux AMD64/ARM64
 
 docker-clean: ## Remove all docker build images
 	docker image rm $(ARM_IMAGE) $(AMD64_IMAGE) $(MIPS64_IMAGE) || true
+
+package: linux-amd64 linux-arm  ## Build deb/rpm packages
+	docker build -t udp-proxy-2020-builder:latest -f Dockerfile.package .
+	docker run --rm \
+		-v $$(pwd)/dist:/root/dist \
+		-e VERSION=$(PROJECT_VERSION) udp-proxy-2020-builder:latest

--- a/package.sh
+++ b/package.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+: ${VERSION?}
+
+function package() {
+    local CPU=$1
+    case $CPU in
+    amd64)
+        local ARCH=x86_64
+        ;;
+    arm64)
+        local ARCH=arm64
+        ;;
+    *)
+        echo "Invalid CPU=$CPU"
+        exit 1
+    esac
+    cat <<EOF >/root/package.yaml
+meta:
+  description: UDP Proxy 2020
+  vendor: Aaron Turner
+  maintainer: Aaron Turner
+  license: MIT
+  url: https://github.com/synfinatic/udp-proxy-2020
+files:
+  "/usr/bin/udp-proxy-2020":
+    file: /root/dist/udp-proxy-2020-${VERSION}-linux-${CPU}
+    mode: "0755"
+    user: "root"
+  "/etc/udp-proxy-2020.conf":
+    file: /root/startup-scripts/systemd/udp-proxy-2020.conf
+    mode: "0644"
+    user: "root"
+    keep: true
+  "/etc/systemd/system/udp-proxy-2020.service":
+    file: /root/startup-scripts/systemd/udp-proxy-2020.service
+    mode: "0644"
+    user: "root"
+scripts:
+    "post-install": /root/package/post-install.sh
+    "pre-remove": /root/package/pre-uninstall.sh
+    "post-remove": /root/package/post-uninstall.sh
+EOF
+    pushd /root/dist
+    pkg --name=udp-proxy-2020 --version=$VERSION --arch=$ARCH --deb ../package.yaml
+    pkg --name=udp-proxy-2020 --version=$VERSION --arch=$ARCH --rpm ../package.yaml
+    popd
+}
+
+package amd64
+package arm64

--- a/package/post-install.sh
+++ b/package/post-install.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+systemctl enable udp-proxy-2020
+systemctl daemon-reload
+
+echo "Be sure to edit /etc/udp-proxy-2020.conf and then run:"
+echo "systemctl start udp-proxy-2020"
+
+exit 0

--- a/package/post-uninstall.sh
+++ b/package/post-uninstall.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+systemctl daemon-reload
+
+exit 0

--- a/package/pre-uninstall.sh
+++ b/package/pre-uninstall.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+systemctl stop udp-proxy-2020
+systemctl disable udp-proxy-2020
+
+exit 0

--- a/startup-scripts/systemd/README.md
+++ b/startup-scripts/systemd/README.md
@@ -2,12 +2,11 @@
 
 ## Setup
 
- 1. Copy systemd config file `udp-proxy-20202.service` to `/usr/lib/systemd/system/`
- 1. Create udp-proxy-2020 config file: `/etc/udp-proxy-2020.conf`  (see below)
- 1. Run `systemctl daemon-reload` to reload the systemctl configuration
+ 1. Copy systemd config file [udp-proxy-20202.service](udp-proxy-2020.service) to `/usr/lib/systemd/system/`
+ 1. Copy the config file [udp-proxy-2020.conf](udp-proxy-2020.conf) to `/etc/udp-proxy-2020.conf`
+ 1. Edit `/etc/udp-proxy-2020.conf` (see below)
  1. Run `systemctl enable udp-proxy-2020` to start the service automatically on boot
  1. Run `systemctl start udp-proxy-2020` to start the service
- 1. Run `systemctl status udp-proxy-2020` to check that the service is running
 
 ## /etc/udp-proxy-2020.conf 
 
@@ -17,6 +16,13 @@ ARGS="*\<arguments passed to udp-proxy-2020\>*"
 
 Typically it will look something like this:
 
-`ARGS="--interface eth0,eth1 --port 9003"`
+`ARGS="--interface eth0 --interface eth1 --port 9003"`
 
 For a full list of possible arguments and their meaning, please run: `udp-proxy-2020 -h`
+
+## Other commands
+
+ 1. Run `systemctl status udp-proxy-2020` to check that the service is running
+ 1. Run `systemctl start udp-proxy-2020` to start the service
+ 1. Run `systemctl stop udp-proxy-2020` to stop the service
+ 1. Run `systemctl daemon-reload` if you ever change the `udp-proxy-2020.service` file

--- a/startup-scripts/systemd/udp-proxy-2020.conf
+++ b/startup-scripts/systemd/udp-proxy-2020.conf
@@ -1,0 +1,9 @@
+# This is just an example, you should edit to taste.  
+# Note that you must _NOT_  quote the value of ARGS!
+
+ARGS=--interface eth0 --interface tun0 --port 9003 --level warn \
+    # you may add another line if the previus line ends in a `\`
+
+
+# note, the backslash above MUST be the very last character on the
+# previous line.  No spaces or tabs!

--- a/startup-scripts/systemd/udp-proxy-2020.service
+++ b/startup-scripts/systemd/udp-proxy-2020.service
@@ -10,7 +10,7 @@ User=root
 Group=root
 Type=simple
 Restart=on-failure
-ExecStart=/usr/local/bin/udp-proxy-2020 ${ARGS}
+ExecStart=/usr/bin/udp-proxy-2020 $ARGS
 
 LimitNOFILE=10000
 TimeoutStopSec=20


### PR DESCRIPTION
`make release` now calls `package` target to build Debian and RedHat package for x86/arm64.