### PR TITLE
startup scripts, fix error with EXTRA_ARGS containing quotation marks

### DIFF
--- a/startup-scripts/Docker/docker-compose.yaml
+++ b/startup-scripts/Docker/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     environment:
       - PORTS=9003
       - INTERFACES=eth0,eth1
-      - EXTRA_ARGS="--debug"
+      - EXTRA_ARGS=-L debug
       - TIMEOUT=250
       - CACHETTL=90
     restart: always


### PR DESCRIPTION
the command `docker-compose up` was failing if EXTRA_ARGS contained quotation marks
removing them fixed the issue and the container was starting correctly