### PR TITLE
Add support for VPN tunnel restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+Fixed:
+- No longer crash when vpn tunnels are restarted on the host #224
+- Added unit and some integration tests
+
+Changed:
+- Complete rewrite
+- New `--decode` flag for decoding packets being forwarded for debugging
+- `--pcap` flag now generates files for the input interface and each in->out combination
+
+
 ## v0.1.4 -- 2026-03-17
 
 Fixed:

--- a/cmd/udp-proxy-2020/main.go
+++ b/cmd/udp-proxy-2020/main.go
@@ -25,6 +25,7 @@ var Tag = "NO-TAG"
 var CommitID = "unknown"
 var Delta = ""
 var newRegistryProcessorByInterface = stages.NewRegistryProcessorByInterface
+var newTransmitterSink = stages.NewTransmitterSink
 
 func main() {
 	cli := parseArgs()
@@ -283,7 +284,7 @@ func discoverBroadcastAddress(dm *proxy.DeviceManager, netif *net.Interface, add
 
 // setupCrossInterfaceSink attaches a cross-interface sink between two ifaceStates.
 func setupCrossInterfaceSink(cli CLI, dm *proxy.DeviceManager, registry *stages.RegistryProcessor, src, dst ifaceState) error {
-	transmitter, err := stages.NewTransmitterSink(dm, dst.name)
+	transmitter, err := newTransmitterSink(dm, dst.name)
 	if err != nil {
 		slog.Error("Failed to create transmitter sink", "source_interface", src.name, "target_interface", dst.name, "error", err)
 		return fmt.Errorf("failed to create transmitter sink from %s to %s", src.name, dst.name)
@@ -295,7 +296,7 @@ func setupCrossInterfaceSink(cli CLI, dm *proxy.DeviceManager, registry *stages.
 		BroadcastAddress: dst.bcastIP,
 		HardwareAddr:     dst.netif.HardwareAddr,
 		Registry:         registry,
-		LinkType:         transmitter.Writer,
+		LinkType:         transmitter.Writer.LinkType(),
 	}
 
 	if cli.Decode {
@@ -303,7 +304,7 @@ func setupCrossInterfaceSink(cli CLI, dm *proxy.DeviceManager, registry *stages.
 	}
 
 	if cli.Pcap {
-		if err := addRoutePcapFileSink(route, cli.PcapPath, src.name, dst.name, transmitter.Writer.LinkType()); err != nil {
+		if err := addRoutePcapFileSink(route, cli.PcapPath, src.name, dst.name, route.LinkType); err != nil {
 			return err
 		}
 	}

--- a/cmd/udp-proxy-2020/main_integration_test.go
+++ b/cmd/udp-proxy-2020/main_integration_test.go
@@ -3,9 +3,12 @@ package main
 import (
 	"context"
 	"errors"
+	"net"
 	"testing"
 	"time"
 
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
 	"github.com/synfinatic/udp-proxy-2020/internal/proxy"
 	"github.com/synfinatic/udp-proxy-2020/internal/proxy/stages"
 )
@@ -29,6 +32,13 @@ func (s *testSource) Name() string {
 type taggedSink struct {
 	target string
 }
+
+type integrationWriter struct {
+	linkType layers.LinkType
+}
+
+func (w *integrationWriter) WritePacketData(_ []byte) error { return nil }
+func (w *integrationWriter) LinkType() layers.LinkType      { return w.linkType }
 
 func (s *taggedSink) Name() string {
 	return "taggedSink(" + s.target + ")"
@@ -142,5 +152,84 @@ func TestBuildSharedRegistries_UsesSingleSharedRegistry(t *testing.T) {
 	}
 	if registries[0] != returned {
 		t.Fatal("expected returned registry to be the shared instance from constructor")
+	}
+}
+
+func TestSetupCrossInterfaceSink_UsesStableLinkTypeAndSurvivesWriterLoss(t *testing.T) {
+	origFactory := newTransmitterSink
+	defer func() {
+		newTransmitterSink = origFactory
+	}()
+
+	newTransmitterSink = func(_ *proxy.DeviceManager, iname string) (*stages.TransmitterSink, error) {
+		return &stages.TransmitterSink{
+			Writer: &integrationWriter{linkType: layers.LinkTypeEthernet},
+			Iname:  iname,
+		}, nil
+	}
+
+	registry, err := stages.NewRegistryProcessorByInterface(time.Hour, nil)
+	if err != nil {
+		t.Fatalf("NewRegistryProcessorByInterface failed: %v", err)
+	}
+
+	src := ifaceState{
+		name:     "eth0",
+		pipeline: proxy.NewPipeline(&testSource{name: "src:eth0"}),
+	}
+	dst := ifaceState{
+		name:      "wg0",
+		netif:     &net.Interface{HardwareAddr: net.HardwareAddr{0, 1, 2, 3, 4, 5}},
+		broadcast: true,
+		bcastIP:   net.IP{10, 10, 10, 255},
+	}
+
+	if err := setupCrossInterfaceSink(CLI{}, &proxy.DeviceManager{}, registry, src, dst); err != nil {
+		t.Fatalf("setupCrossInterfaceSink failed: %v", err)
+	}
+
+	if len(src.pipeline.Sinks) != 1 {
+		t.Fatalf("expected exactly one sink on source pipeline, got %d", len(src.pipeline.Sinks))
+	}
+
+	route, ok := src.pipeline.Sinks[0].(*stages.RouteSink)
+	if !ok {
+		t.Fatalf("expected RouteSink, got %T", src.pipeline.Sinks[0])
+	}
+	if route.LinkType != layers.LinkTypeEthernet {
+		t.Fatalf("expected stable route link type Ethernet, got %v", route.LinkType)
+	}
+
+	if len(route.Sinks) != 1 {
+		t.Fatalf("expected route sink fanout to contain one sink, got %d", len(route.Sinks))
+	}
+	tx, ok := route.Sinks[0].(*stages.TransmitterSink)
+	if !ok {
+		t.Fatalf("expected transmitter sink, got %T", route.Sinks[0])
+	}
+
+	// Simulate reconnect/drop mode after interface loss.
+	tx.Writer = nil
+
+	raw := []byte{
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		0x00, 0x11, 0x22, 0x33, 0x44, 0x55,
+		0x08, 0x00,
+		0x45, 0x00, 0x00, 0x1c,
+		0x00, 0x00, 0x40, 0x00,
+		0x40, 0x11, 0x00, 0x00,
+		0x0a, 0x00, 0x00, 0x01,
+		0x0a, 0x00, 0x00, 0x02,
+		0x04, 0xd2, 0x04, 0xd2,
+		0x00, 0x08, 0x00, 0x00,
+	}
+	pkt := &proxy.Packet{
+		Raw:              raw,
+		Packet:           gopacket.NewPacket(raw, layers.LayerTypeEthernet, gopacket.Default),
+		ArrivalInterface: "eth0",
+	}
+
+	if err := route.Write(pkt); err != nil {
+		t.Fatalf("route write should remain non-fatal while writer is unavailable: %v", err)
 	}
 }

--- a/internal/proxy/device_manager.go
+++ b/internal/proxy/device_manager.go
@@ -207,29 +207,9 @@ func (dm *DeviceManager) CreateWriterHandle(iname string) (*pcap.Handle, error) 
 		return handle, nil
 	}
 	dm.mu.RUnlock()
-	slog.Debug("Creating writer handle for interface", slog.String("interface", iname))
-
-	inactive, err := pcap.NewInactiveHandle(iname)
+	handle, err := dm.newWriterHandle(iname, false)
 	if err != nil {
 		return nil, err
-	}
-	defer inactive.CleanUp()
-
-	if err = inactive.SetPromisc(false); err != nil {
-		return nil, err
-	}
-	if err = inactive.SetSnapLen(9000); err != nil {
-		return nil, err
-	}
-
-	handle, err := inactive.Activate()
-	if err != nil {
-		return nil, err
-	}
-
-	if !dm.isValidLinkType(handle.LinkType()) {
-		handle.Close()
-		return nil, fmt.Errorf("interface %s has an unsupported link type: %s", iname, handle.LinkType())
 	}
 
 	dm.mu.Lock()
@@ -243,7 +223,15 @@ func (dm *DeviceManager) CreateWriterHandle(iname string) (*pcap.Handle, error) 
 // the given interface without storing it in the shared handle cache. This is
 // used when each caller must own and close its own handle independently.
 func (dm *DeviceManager) CreateIsolatedWriterHandle(iname string) (*pcap.Handle, error) {
-	slog.Debug("Creating isolated writer handle for interface", slog.String("interface", iname))
+	return dm.newWriterHandle(iname, true)
+}
+
+func (dm *DeviceManager) newWriterHandle(iname string, isolated bool) (*pcap.Handle, error) {
+	if isolated {
+		slog.Debug("Creating isolated writer handle for interface", slog.String("interface", iname))
+	} else {
+		slog.Debug("Creating writer handle for interface", slog.String("interface", iname))
+	}
 
 	inactive, err := pcap.NewInactiveHandle(iname)
 	if err != nil {

--- a/internal/proxy/device_manager.go
+++ b/internal/proxy/device_manager.go
@@ -239,6 +239,48 @@ func (dm *DeviceManager) CreateWriterHandle(iname string) (*pcap.Handle, error) 
 	return handle, nil
 }
 
+// CreateIsolatedWriterHandle initializes a dedicated libpcap writer handle for
+// the given interface without storing it in the shared handle cache. This is
+// used when each caller must own and close its own handle independently.
+func (dm *DeviceManager) CreateIsolatedWriterHandle(iname string) (*pcap.Handle, error) {
+	slog.Debug("Creating isolated writer handle for interface", slog.String("interface", iname))
+
+	inactive, err := pcap.NewInactiveHandle(iname)
+	if err != nil {
+		return nil, err
+	}
+	defer inactive.CleanUp()
+
+	if err = inactive.SetPromisc(false); err != nil {
+		return nil, err
+	}
+	if err = inactive.SetSnapLen(9000); err != nil {
+		return nil, err
+	}
+
+	handle, err := inactive.Activate()
+	if err != nil {
+		return nil, err
+	}
+
+	if !dm.isValidLinkType(handle.LinkType()) {
+		handle.Close()
+		return nil, fmt.Errorf("interface %s has an unsupported link type: %s", iname, handle.LinkType())
+	}
+
+	return handle, nil
+}
+
+// InterfaceAvailable refreshes the interface list and reports whether iname is
+// currently present and has at least one address.
+func (dm *DeviceManager) InterfaceAvailable(iname string) bool {
+	_ = dm.Refresh() // best-effort; ignore transient errors
+	dm.mu.RLock()
+	defer dm.mu.RUnlock()
+	_, ok := dm.interfaces[iname]
+	return ok
+}
+
 func (dm *DeviceManager) Close(iname string, direction PcapHandleDirection) error {
 	key := deviceManagerKey(iname, direction)
 	dm.mu.Lock()

--- a/internal/proxy/stages/pcap_source.go
+++ b/internal/proxy/stages/pcap_source.go
@@ -2,12 +2,18 @@ package stages
 
 import (
 	"context"
-	"io"
+	"log/slog"
 	"time"
 
 	"github.com/gopacket/gopacket"
 	"github.com/gopacket/gopacket/pcap"
 	"github.com/synfinatic/udp-proxy-2020/internal/proxy"
+)
+
+const (
+	reconnectInitialDelay = 1 * time.Second
+	reconnectMaxDelay     = 30 * time.Second
+	interfacePollInterval = 1 * time.Second
 )
 
 // PcapSource reads packets from a libpcap handle.
@@ -17,6 +23,13 @@ type PcapSource struct {
 	packetSource *gopacket.PacketSource
 	packets      chan gopacket.Packet
 	iname        string
+	promisc      bool
+	timeout      time.Duration
+
+	createReaderHandle func(iname string, promisc bool, timeout time.Duration) (*pcap.Handle, error)
+	closeReaderHandle  func(iname string, direction proxy.PcapHandleDirection) error
+	interfaceAvailable func(iname string) bool
+	newPacketSource    func(handle *pcap.Handle) (*gopacket.PacketSource, chan gopacket.Packet)
 }
 
 // NewPcapSource creates a new PcapSource.
@@ -27,11 +40,20 @@ func NewPcapSource(dm *proxy.DeviceManager, iname string, promisc bool, timeout 
 	}
 	packetSource := gopacket.NewPacketSource(handle, handle.LinkType())
 	return &PcapSource{
-		dm:           dm,
-		handle:       handle,
-		packetSource: packetSource,
-		packets:      packetSource.Packets(),
-		iname:        iname,
+		dm:                 dm,
+		handle:             handle,
+		packetSource:       packetSource,
+		packets:            packetSource.Packets(),
+		iname:              iname,
+		promisc:            promisc,
+		timeout:            timeout,
+		createReaderHandle: dm.CreateReaderHandle,
+		closeReaderHandle:  dm.Close,
+		interfaceAvailable: dm.InterfaceAvailable,
+		newPacketSource: func(h *pcap.Handle) (*gopacket.PacketSource, chan gopacket.Packet) {
+			ps := gopacket.NewPacketSource(h, h.LinkType())
+			return ps, ps.Packets()
+		},
 	}, nil
 }
 
@@ -39,22 +61,102 @@ func (s *PcapSource) Handle() *pcap.Handle {
 	return s.handle
 }
 
-// Read reads the next packet from the PCAP handle.
-func (s *PcapSource) Read(ctx context.Context) (*proxy.Packet, error) {
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case p, ok := <-s.packets:
-		if !ok {
-			return nil, io.EOF
+// reconnect closes the stale pcap handle and waits for the interface to come
+// back up, then opens a fresh handle and resets the packet channel. It returns
+// when reconnection succeeds or ctx is cancelled.
+func (s *PcapSource) reconnect(ctx context.Context, reason string) error {
+	slog.Warn("pcap source lost, waiting for interface to come back",
+		slog.String("interface", s.iname),
+		slog.String("reason", reason))
+
+	// Close the old handle; ignore "not found" — it may already be gone.
+	_ = s.closeReaderHandle(s.iname, proxy.Reader)
+
+	delay := reconnectInitialDelay
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(delay):
 		}
 
-		return &proxy.Packet{
-			Raw:              p.Data(),
-			Metadata:         p.Metadata().CaptureInfo,
-			Packet:           p,
-			ArrivalInterface: s.iname,
-		}, nil
+		handle, err := s.createReaderHandle(s.iname, s.promisc, s.timeout)
+		if err != nil {
+			slog.Debug("interface not yet available, retrying",
+				slog.String("interface", s.iname),
+				slog.String("reason", reason),
+				slog.Duration("retry_in", delay),
+				slog.String("error", err.Error()))
+			if delay < reconnectMaxDelay {
+				delay *= 2
+				if delay > reconnectMaxDelay {
+					delay = reconnectMaxDelay
+				}
+			}
+			continue
+		}
+
+		packetSource, packets := s.newPacketSource(handle)
+		s.handle = handle
+		s.packetSource = packetSource
+		s.packets = packets
+		slog.Info("interface reconnected",
+			slog.String("interface", s.iname),
+			slog.String("reason", reason))
+		return nil
+	}
+}
+
+// Read reads the next packet from the PCAP handle. If the underlying interface
+// disappears (e.g. VPN tunnel restart), Read blocks and retries until the
+// interface comes back or ctx is cancelled.
+func (s *PcapSource) Read(ctx context.Context) (*proxy.Packet, error) {
+	ticker := time.NewTicker(interfacePollInterval)
+	defer ticker.Stop()
+
+	interfaceWasDown := false
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+			available := s.interfaceAvailable(s.iname)
+			if !available {
+				if !interfaceWasDown {
+					slog.Warn("interface appears down, awaiting recovery",
+						slog.String("interface", s.iname))
+				}
+				interfaceWasDown = true
+				continue
+			}
+
+			if interfaceWasDown {
+				slog.Info("interface is back, reconnecting capture handle",
+					slog.String("interface", s.iname))
+				if err := s.reconnect(ctx, "interface_down_up"); err != nil {
+					return nil, err
+				}
+				interfaceWasDown = false
+			}
+		case p, ok := <-s.packets:
+			if !ok {
+				// Interface went away — attempt to reconnect.
+				if err := s.reconnect(ctx, "packets_channel_closed"); err != nil {
+					return nil, err
+				}
+				interfaceWasDown = false
+				// Restart the select with the new packets channel.
+				continue
+			}
+
+			return &proxy.Packet{
+				Raw:              p.Data(),
+				Metadata:         p.Metadata().CaptureInfo,
+				Packet:           p,
+				ArrivalInterface: s.iname,
+			}, nil
+		}
 	}
 }
 

--- a/internal/proxy/stages/pcap_source.go
+++ b/internal/proxy/stages/pcap_source.go
@@ -13,7 +13,6 @@ import (
 const (
 	reconnectInitialDelay = 1 * time.Second
 	reconnectMaxDelay     = 30 * time.Second
-	interfacePollInterval = 1 * time.Second
 )
 
 // PcapSource reads packets from a libpcap handle.
@@ -30,6 +29,8 @@ type PcapSource struct {
 	closeReaderHandle  func(iname string, direction proxy.PcapHandleDirection) error
 	interfaceAvailable func(iname string) bool
 	newPacketSource    func(handle *pcap.Handle) (*gopacket.PacketSource, chan gopacket.Packet)
+	reconnectSignal    chan struct{}
+	monitorCancel      context.CancelFunc
 }
 
 // NewPcapSource creates a new PcapSource.
@@ -39,7 +40,7 @@ func NewPcapSource(dm *proxy.DeviceManager, iname string, promisc bool, timeout 
 		return nil, err
 	}
 	packetSource := gopacket.NewPacketSource(handle, handle.LinkType())
-	return &PcapSource{
+	source := &PcapSource{
 		dm:                 dm,
 		handle:             handle,
 		packetSource:       packetSource,
@@ -54,7 +55,53 @@ func NewPcapSource(dm *proxy.DeviceManager, iname string, promisc bool, timeout 
 			ps := gopacket.NewPacketSource(h, h.LinkType())
 			return ps, ps.Packets()
 		},
-	}, nil
+		reconnectSignal: make(chan struct{}, 1),
+		monitorCancel:   nil,
+	}
+	source.startInterfaceMonitor()
+	return source, nil
+}
+
+func (s *PcapSource) startInterfaceMonitor() {
+	if s.interfaceAvailable == nil {
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s.monitorCancel = cancel
+
+	go func() {
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+
+		interfaceWasDown := false
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				available := s.interfaceAvailable(s.iname)
+				if !available {
+					if !interfaceWasDown {
+						slog.Warn("interface appears down, awaiting recovery",
+							slog.String("interface", s.iname))
+					}
+					interfaceWasDown = true
+					continue
+				}
+
+				if interfaceWasDown {
+					slog.Info("interface is back, reconnecting capture handle",
+						slog.String("interface", s.iname))
+					select {
+					case s.reconnectSignal <- struct{}{}:
+					default:
+					}
+					interfaceWasDown = false
+				}
+			}
+		}
+	}()
 }
 
 func (s *PcapSource) Handle() *pcap.Handle {
@@ -107,45 +154,27 @@ func (s *PcapSource) reconnect(ctx context.Context, reason string) error {
 	}
 }
 
-// Read reads the next packet from the PCAP handle. If the underlying interface
-// disappears (e.g. VPN tunnel restart), Read blocks and retries until the
-// interface comes back or ctx is cancelled.
+// Read reads the next packet from the PCAP handle. If the packet channel is
+// closed because the interface/handle disappeared, it reconnects until the
+// handle is restored or ctx is cancelled.
 func (s *PcapSource) Read(ctx context.Context) (*proxy.Packet, error) {
-	ticker := time.NewTicker(interfacePollInterval)
-	defer ticker.Stop()
-
-	interfaceWasDown := false
+	reconnectSignal := s.reconnectSignal
 
 	for {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
-		case <-ticker.C:
-			available := s.interfaceAvailable(s.iname)
-			if !available {
-				if !interfaceWasDown {
-					slog.Warn("interface appears down, awaiting recovery",
-						slog.String("interface", s.iname))
-				}
-				interfaceWasDown = true
-				continue
+		case <-reconnectSignal:
+			if err := s.reconnect(ctx, "interface_down_up"); err != nil {
+				return nil, err
 			}
-
-			if interfaceWasDown {
-				slog.Info("interface is back, reconnecting capture handle",
-					slog.String("interface", s.iname))
-				if err := s.reconnect(ctx, "interface_down_up"); err != nil {
-					return nil, err
-				}
-				interfaceWasDown = false
-			}
+			continue
 		case p, ok := <-s.packets:
 			if !ok {
 				// Interface went away — attempt to reconnect.
 				if err := s.reconnect(ctx, "packets_channel_closed"); err != nil {
 					return nil, err
 				}
-				interfaceWasDown = false
 				// Restart the select with the new packets channel.
 				continue
 			}
@@ -162,6 +191,9 @@ func (s *PcapSource) Read(ctx context.Context) (*proxy.Packet, error) {
 
 // Close closes the underlying PCAP handle
 func (s *PcapSource) Close() error {
+	if s.monitorCancel != nil {
+		s.monitorCancel()
+	}
 	return s.dm.Close(s.iname, proxy.Reader)
 }
 

--- a/internal/proxy/stages/pcap_source_test.go
+++ b/internal/proxy/stages/pcap_source_test.go
@@ -1,0 +1,76 @@
+package stages
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/pcap"
+	"github.com/synfinatic/udp-proxy-2020/internal/proxy"
+)
+
+func TestPcapSourceRead_ReconnectsAfterInterfaceDownUp(t *testing.T) {
+	oldPackets := make(chan gopacket.Packet)
+	newPackets := make(chan gopacket.Packet, 1)
+
+	var closeCalls int32
+	var createCalls int32
+	var pollCalls int32
+	created := make(chan struct{}, 1)
+
+	s := &PcapSource{
+		iname:   "wg0",
+		promisc: true,
+		timeout: time.Second,
+		packets: oldPackets,
+		interfaceAvailable: func(string) bool {
+			// First poll: down. Subsequent polls: up.
+			return atomic.AddInt32(&pollCalls, 1) > 1
+		},
+		closeReaderHandle: func(string, proxy.PcapHandleDirection) error {
+			atomic.AddInt32(&closeCalls, 1)
+			return nil
+		},
+		createReaderHandle: func(string, bool, time.Duration) (*pcap.Handle, error) {
+			atomic.AddInt32(&createCalls, 1)
+			select {
+			case created <- struct{}{}:
+			default:
+			}
+			return nil, nil
+		},
+		newPacketSource: func(_ *pcap.Handle) (*gopacket.PacketSource, chan gopacket.Packet) {
+			return nil, newPackets
+		},
+	}
+
+	raw := []byte{0, 1, 2, 3, 4, 5}
+	pkt := gopacket.NewPacket(raw, gopacket.LayerTypePayload, gopacket.Default)
+
+	go func() {
+		<-created
+		newPackets <- pkt
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+
+	out, err := s.Read(ctx)
+	if err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+	if out == nil {
+		t.Fatal("expected packet, got nil")
+	}
+	if out.ArrivalInterface != "wg0" {
+		t.Fatalf("expected arrival interface wg0, got %s", out.ArrivalInterface)
+	}
+	if atomic.LoadInt32(&closeCalls) == 0 {
+		t.Fatal("expected reader handle close during reconnect")
+	}
+	if atomic.LoadInt32(&createCalls) == 0 {
+		t.Fatal("expected reader handle create during reconnect")
+	}
+}

--- a/internal/proxy/stages/pcap_source_test.go
+++ b/internal/proxy/stages/pcap_source_test.go
@@ -11,13 +11,12 @@ import (
 	"github.com/synfinatic/udp-proxy-2020/internal/proxy"
 )
 
-func TestPcapSourceRead_ReconnectsAfterInterfaceDownUp(t *testing.T) {
+func TestPcapSourceRead_ReconnectsAfterPacketChannelClose(t *testing.T) {
 	oldPackets := make(chan gopacket.Packet)
 	newPackets := make(chan gopacket.Packet, 1)
 
 	var closeCalls int32
 	var createCalls int32
-	var pollCalls int32
 	created := make(chan struct{}, 1)
 
 	s := &PcapSource{
@@ -25,10 +24,6 @@ func TestPcapSourceRead_ReconnectsAfterInterfaceDownUp(t *testing.T) {
 		promisc: true,
 		timeout: time.Second,
 		packets: oldPackets,
-		interfaceAvailable: func(string) bool {
-			// First poll: down. Subsequent polls: up.
-			return atomic.AddInt32(&pollCalls, 1) > 1
-		},
 		closeReaderHandle: func(string, proxy.PcapHandleDirection) error {
 			atomic.AddInt32(&closeCalls, 1)
 			return nil
@@ -48,8 +43,70 @@ func TestPcapSourceRead_ReconnectsAfterInterfaceDownUp(t *testing.T) {
 
 	raw := []byte{0, 1, 2, 3, 4, 5}
 	pkt := gopacket.NewPacket(raw, gopacket.LayerTypePayload, gopacket.Default)
+	close(oldPackets)
 
 	go func() {
+		<-created
+		newPackets <- pkt
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+
+	out, err := s.Read(ctx)
+	if err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+	if out == nil {
+		t.Fatal("expected packet, got nil")
+	}
+	if out.ArrivalInterface != "wg0" {
+		t.Fatalf("expected arrival interface wg0, got %s", out.ArrivalInterface)
+	}
+	if atomic.LoadInt32(&closeCalls) == 0 {
+		t.Fatal("expected reader handle close during reconnect")
+	}
+	if atomic.LoadInt32(&createCalls) == 0 {
+		t.Fatal("expected reader handle create during reconnect")
+	}
+}
+
+func TestPcapSourceRead_ReconnectsAfterSignal(t *testing.T) {
+	oldPackets := make(chan gopacket.Packet)
+	newPackets := make(chan gopacket.Packet, 1)
+
+	var closeCalls int32
+	var createCalls int32
+	created := make(chan struct{}, 1)
+
+	s := &PcapSource{
+		iname:           "wg0",
+		promisc:         true,
+		timeout:         time.Second,
+		packets:         oldPackets,
+		reconnectSignal: make(chan struct{}, 1),
+		closeReaderHandle: func(string, proxy.PcapHandleDirection) error {
+			atomic.AddInt32(&closeCalls, 1)
+			return nil
+		},
+		createReaderHandle: func(string, bool, time.Duration) (*pcap.Handle, error) {
+			atomic.AddInt32(&createCalls, 1)
+			select {
+			case created <- struct{}{}:
+			default:
+			}
+			return nil, nil
+		},
+		newPacketSource: func(_ *pcap.Handle) (*gopacket.PacketSource, chan gopacket.Packet) {
+			return nil, newPackets
+		},
+	}
+
+	raw := []byte{6, 7, 8, 9}
+	pkt := gopacket.NewPacket(raw, gopacket.LayerTypePayload, gopacket.Default)
+
+	go func() {
+		s.reconnectSignal <- struct{}{}
 		<-created
 		newPackets <- pkt
 	}()

--- a/internal/proxy/stages/route_sink.go
+++ b/internal/proxy/stages/route_sink.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net"
 
+	"github.com/gopacket/gopacket/layers"
 	"github.com/synfinatic/udp-proxy-2020/internal/proxy"
 	proxyrewrite "github.com/synfinatic/udp-proxy-2020/internal/proxy/rewrite"
 )
@@ -18,7 +19,7 @@ type RouteSink struct {
 	BroadcastAddress net.IP
 	HardwareAddr     net.HardwareAddr
 	Registry         *RegistryProcessor
-	LinkType         proxy.PacketWriter
+	LinkType         layers.LinkType
 	Processors       []proxy.Processor
 	Sinks            []proxy.Sink
 }
@@ -58,7 +59,7 @@ func (s *RouteSink) writeToTarget(pkt *proxy.Packet, target routeTarget) {
 		TargetIP:               target.IP,
 		TargetMAC:              target.MAC,
 		SourceMAC:              s.HardwareAddr,
-		EgressLinkType:         s.LinkType.LinkType(),
+		EgressLinkType:         s.LinkType,
 		AllowBroadcastDstMAC:   target.AllowBroadcastMAC,
 		ForceBroadcastDestMAC:  target.BroadcastDestMAC,
 		OutputArrivalInterface: s.Iname,

--- a/internal/proxy/stages/route_sink_test.go
+++ b/internal/proxy/stages/route_sink_test.go
@@ -1,6 +1,7 @@
 package stages
 
 import (
+	"context"
 	"errors"
 	"net"
 	"testing"
@@ -10,13 +11,6 @@ import (
 	"github.com/gopacket/gopacket/layers"
 	"github.com/synfinatic/udp-proxy-2020/internal/proxy"
 )
-
-type routeSinkMockWriter struct {
-	linkType layers.LinkType
-}
-
-func (m *routeSinkMockWriter) WritePacketData(_ []byte) error { return nil }
-func (m *routeSinkMockWriter) LinkType() layers.LinkType      { return m.linkType }
 
 type routeSinkTestSink struct {
 	writes int
@@ -199,7 +193,7 @@ func TestRouteSink_Write_FansOutToTargetsAndSinks(t *testing.T) {
 		BroadcastAddress: net.IP{10, 0, 1, 255},
 		HardwareAddr:     net.HardwareAddr{0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc},
 		Registry:         registry,
-		LinkType:         &routeSinkMockWriter{linkType: layers.LinkTypeEthernet},
+		LinkType:         layers.LinkTypeEthernet,
 		Processors:       []proxy.Processor{proc},
 		Sinks:            []proxy.Sink{sinkA, sinkB},
 	}
@@ -250,7 +244,7 @@ func TestRouteSink_Write_DropsWhenProcessorReturnsFalse(t *testing.T) {
 		Broadcast:        true,
 		BroadcastAddress: net.IP{10, 0, 2, 255},
 		HardwareAddr:     net.HardwareAddr{0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc},
-		LinkType:         &routeSinkMockWriter{linkType: layers.LinkTypeEthernet},
+		LinkType:         layers.LinkTypeEthernet,
 		Processors:       []proxy.Processor{proc},
 		Sinks:            []proxy.Sink{capture},
 	}
@@ -285,7 +279,7 @@ func TestRouteSink_Write_SkipsSinkWhenProcessorErrors(t *testing.T) {
 		Broadcast:        true,
 		BroadcastAddress: net.IP{10, 0, 3, 255},
 		HardwareAddr:     net.HardwareAddr{0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc},
-		LinkType:         &routeSinkMockWriter{linkType: layers.LinkTypeEthernet},
+		LinkType:         layers.LinkTypeEthernet,
 		Processors:       []proxy.Processor{proc},
 		Sinks:            []proxy.Sink{capture},
 	}
@@ -326,7 +320,7 @@ func TestRouteSink_Write_RewriteErrorSkipsTarget(t *testing.T) {
 		Broadcast:    false,
 		HardwareAddr: net.HardwareAddr{0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc},
 		Registry:     registry,
-		LinkType:     &routeSinkMockWriter{linkType: layers.LinkTypeEthernet},
+		LinkType:     layers.LinkTypeEthernet,
 		Sinks:        []proxy.Sink{capture},
 	}
 
@@ -362,5 +356,60 @@ func TestRouteSink_Close_ReturnsFirstErrorAndClosesAll(t *testing.T) {
 	}
 	if sinkA.closed != 1 || sinkB.closed != 1 {
 		t.Fatalf("expected all sinks to be closed once: sinkA=%d sinkB=%d", sinkA.closed, sinkB.closed)
+	}
+}
+
+// Integration-style regression test: RouteSink should keep rewriting safely
+// while TransmitterSink is in reconnect mode after write failures.
+func TestRouteSink_WithTransmitterReconnect_DoesNotPanic(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tx := &TransmitterSink{
+		dm:     &proxy.DeviceManager{},
+		Writer: &mockWriter{linkType: layers.LinkTypeEthernet, writeErr: errors.New("send: Device not configured")},
+		Iname:  "wg0",
+		ctx:    ctx,
+		cancel: cancel,
+	}
+
+	route := &RouteSink{
+		Iname:            "wg0",
+		Broadcast:        true,
+		BroadcastAddress: net.IP{10, 7, 0, 255},
+		HardwareAddr:     net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
+		LinkType:         layers.LinkTypeEthernet,
+		Sinks:            []proxy.Sink{tx},
+	}
+
+	pkt := buildEthernetPacket(
+		t,
+		net.IP{10, 0, 0, 1},
+		net.IP{10, 0, 0, 2},
+		net.HardwareAddr{0, 1, 2, 3, 4, 5},
+		net.HardwareAddr{6, 7, 8, 9, 10, 11},
+		[]byte("hello"),
+		"eth-in",
+	)
+
+	if err := route.Write(pkt); err != nil {
+		t.Fatalf("first route write failed: %v", err)
+	}
+
+	tx.mu.Lock()
+	if !tx.reconnecting {
+		tx.mu.Unlock()
+		t.Fatal("expected transmitter to enter reconnecting state after write error")
+	}
+	if tx.Writer != nil {
+		tx.mu.Unlock()
+		t.Fatal("expected writer to be nil while reconnecting")
+	}
+	tx.mu.Unlock()
+
+	// Second write should still succeed from RouteSink's perspective while
+	// transmitter reconnect is in progress (packet is dropped gracefully).
+	if err := route.Write(pkt); err != nil {
+		t.Fatalf("second route write failed while reconnecting: %v", err)
 	}
 }

--- a/internal/proxy/stages/transmitter.go
+++ b/internal/proxy/stages/transmitter.go
@@ -85,6 +85,10 @@ func (s *TransmitterSink) reconnectLoop() {
 	slog.Warn("waiting for interface to come back",
 		slog.String("interface", s.Iname))
 
+	if s.ctx == nil {
+		return
+	}
+
 	delay := reconnectInitialDelay
 	for {
 		select {
@@ -128,7 +132,9 @@ func (s *TransmitterSink) reconnectLoop() {
 
 // Close cancels any in-progress reconnect and closes the underlying PCAP handle.
 func (s *TransmitterSink) Close() error {
-	s.cancel()
+	if s.cancel != nil {
+		s.cancel()
+	}
 
 	s.mu.Lock()
 	staleWriter := s.Writer

--- a/internal/proxy/stages/transmitter.go
+++ b/internal/proxy/stages/transmitter.go
@@ -1,29 +1,44 @@
 package stages
 
 import (
+	"context"
 	"fmt"
+	"log/slog"
+	"sync"
+	"time"
 
 	"github.com/synfinatic/udp-proxy-2020/internal/proxy"
 )
 
 // TransmitterSink sends packets to a physical interface.
 type TransmitterSink struct {
-	dm     *proxy.DeviceManager
-	Writer proxy.PacketWriter
-	Iname  string
+	dm           *proxy.DeviceManager
+	mu           sync.Mutex // protects Writer and reconnecting
+	Writer       proxy.PacketWriter
+	Iname        string
+	reconnecting bool
+	ctx          context.Context
+	cancel       context.CancelFunc
+	createWriter func(iname string) (proxy.PacketWriter, error)
 }
 
 // NewTransmitterSink creates a new TransmitterSink.
 func NewTransmitterSink(dm *proxy.DeviceManager, iname string) (*TransmitterSink, error) {
-	handle, err := dm.CreateWriterHandle(iname)
+	handle, err := dm.CreateIsolatedWriterHandle(iname)
 	if err != nil {
 		return nil, err
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
 	return &TransmitterSink{
 		dm:     dm,
 		Writer: handle,
 		Iname:  iname,
+		ctx:    ctx,
+		cancel: cancel,
+		createWriter: func(iname string) (proxy.PacketWriter, error) {
+			return dm.CreateIsolatedWriterHandle(iname)
+		},
 	}, nil
 }
 
@@ -35,10 +50,100 @@ func (s *TransmitterSink) Write(pkt *proxy.Packet) error {
 	if pkt == nil {
 		return nil
 	}
-	return s.Writer.WritePacketData(pkt.Raw)
+
+	s.mu.Lock()
+	if s.Writer == nil {
+		// Reconnect is in progress; drop this packet.
+		s.mu.Unlock()
+		return nil
+	}
+
+	// Keep the lock while writing so no other goroutine can close/replace the
+	// underlying pcap handle concurrently.
+	if err := s.Writer.WritePacketData(pkt.Raw); err != nil {
+		staleWriter := s.Writer
+		slog.Warn("transmitter write failed, initiating reconnect",
+			slog.String("interface", s.Iname),
+			slog.String("error", err.Error()))
+
+		if !s.reconnecting {
+			s.reconnecting = true
+			s.Writer = nil
+			closePacketWriter(staleWriter)
+			go s.reconnectLoop()
+		}
+		s.mu.Unlock()
+		return nil
+	}
+	s.mu.Unlock()
+	return nil
 }
 
-// Close closes the underlying PCAP handle
+// reconnectLoop runs in a goroutine and retries opening the writer handle until
+// it succeeds or the sink is closed.
+func (s *TransmitterSink) reconnectLoop() {
+	slog.Warn("waiting for interface to come back",
+		slog.String("interface", s.Iname))
+
+	delay := reconnectInitialDelay
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		case <-time.After(delay):
+		}
+
+		if s.createWriter == nil {
+			return
+		}
+
+		handle, err := s.createWriter(s.Iname)
+		if err != nil {
+			slog.Debug("interface not yet available for writing, retrying",
+				slog.String("interface", s.Iname),
+				slog.Duration("retry_in", delay),
+				slog.String("error", err.Error()))
+			if delay < reconnectMaxDelay {
+				delay *= 2
+				if delay > reconnectMaxDelay {
+					delay = reconnectMaxDelay
+				}
+			}
+			continue
+		}
+
+		s.mu.Lock()
+		if s.ctx.Err() != nil {
+			s.mu.Unlock()
+			return
+		}
+		s.Writer = handle
+		s.reconnecting = false
+		s.mu.Unlock()
+		slog.Info("interface reconnected for writing",
+			slog.String("interface", s.Iname))
+		return
+	}
+}
+
+// Close cancels any in-progress reconnect and closes the underlying PCAP handle.
 func (s *TransmitterSink) Close() error {
-	return s.dm.Close(s.Iname, proxy.Writer)
+	s.cancel()
+
+	s.mu.Lock()
+	staleWriter := s.Writer
+	s.Writer = nil
+	s.reconnecting = false
+	s.mu.Unlock()
+	closePacketWriter(staleWriter)
+	return nil
+}
+
+func closePacketWriter(w proxy.PacketWriter) {
+	if w == nil {
+		return
+	}
+	if c, ok := w.(interface{ Close() }); ok {
+		c.Close()
+	}
 }

--- a/internal/proxy/stages/transmitter_test.go
+++ b/internal/proxy/stages/transmitter_test.go
@@ -1,7 +1,10 @@
 package stages
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/gopacket/gopacket/layers"
 	"github.com/synfinatic/udp-proxy-2020/internal/proxy"
@@ -22,12 +25,19 @@ func (m *mockWriter) LinkType() layers.LinkType {
 	return m.linkType
 }
 
+func newTestTransmitter(w proxy.PacketWriter) *TransmitterSink {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &TransmitterSink{
+		Writer: w,
+		Iname:  "eth0",
+		ctx:    ctx,
+		cancel: cancel,
+	}
+}
+
 func TestTransmitterSink_Write(t *testing.T) {
 	writer := &mockWriter{linkType: layers.LinkTypeEthernet}
-	s := &TransmitterSink{
-		Writer: writer,
-		Iname:  "eth0",
-	}
+	s := newTestTransmitter(writer)
 
 	pkt := &proxy.Packet{Raw: []byte("payload")}
 	if err := s.Write(pkt); err != nil {
@@ -41,10 +51,7 @@ func TestTransmitterSink_Write(t *testing.T) {
 
 func TestTransmitterSink_WriteNilPacket(t *testing.T) {
 	writer := &mockWriter{linkType: layers.LinkTypeEthernet}
-	s := &TransmitterSink{
-		Writer: writer,
-		Iname:  "eth0",
-	}
+	s := newTestTransmitter(writer)
 
 	if err := s.Write(nil); err != nil {
 		t.Fatalf("Write(nil) failed: %v", err)
@@ -52,5 +59,110 @@ func TestTransmitterSink_WriteNilPacket(t *testing.T) {
 
 	if writer.data == nil {
 		return
+	}
+}
+
+// TestTransmitterSink_WriteErrorTriggersReconnect verifies that a write failure
+// sets Writer to nil (dropping subsequent packets) and marks reconnecting.
+func TestTransmitterSink_WriteErrorTriggersReconnect(t *testing.T) {
+	writer := &mockWriter{
+		linkType: layers.LinkTypeEthernet,
+		writeErr: errors.New("interface gone"),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately so the goroutine doesn't spin or touch pcap
+	dm := &proxy.DeviceManager{}
+	s := &TransmitterSink{
+		dm:     dm,
+		Writer: writer,
+		Iname:  "eth0",
+		ctx:    ctx,
+		cancel: cancel,
+	}
+
+	pkt := &proxy.Packet{Raw: []byte("payload")}
+	if err := s.Write(pkt); err != nil {
+		t.Fatalf("Write should not return an error: %v", err)
+	}
+
+	s.mu.Lock()
+	writerNil := s.Writer == nil
+	reconnecting := s.reconnecting
+	s.mu.Unlock()
+
+	if !writerNil {
+		t.Error("expected Writer to be nil after write error")
+	}
+	if !reconnecting {
+		t.Error("expected reconnecting to be true after write error")
+	}
+}
+
+// TestTransmitterSink_WriteWhileReconnecting verifies that packets are silently
+// dropped (no error, no panic) while Writer is nil.
+func TestTransmitterSink_WriteWhileReconnecting(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &TransmitterSink{
+		Writer:       nil, // simulates mid-reconnect state
+		Iname:        "eth0",
+		reconnecting: true,
+		ctx:          ctx,
+		cancel:       cancel,
+	}
+
+	pkt := &proxy.Packet{Raw: []byte("payload")}
+	if err := s.Write(pkt); err != nil {
+		t.Fatalf("Write while reconnecting should not return an error: %v", err)
+	}
+}
+
+// TestTransmitterSink_ReconnectLoopExitsOnCancel verifies that reconnectLoop
+// exits promptly when the sink's context is cancelled, without panicking even
+// when dm is nil (only safe because the loop exits before touching dm).
+func TestTransmitterSink_ReconnectLoopExitsOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &TransmitterSink{
+		dm:           nil, // not reached because ctx is cancelled before first retry
+		Writer:       nil,
+		Iname:        "eth0",
+		reconnecting: true,
+		ctx:          ctx,
+		cancel:       cancel,
+	}
+
+	cancel() // cancel before the goroutine even starts its first wait
+	done := make(chan struct{})
+	go func() {
+		s.reconnectLoop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// ok
+	case <-time.After(2 * time.Second):
+		t.Fatal("reconnectLoop did not exit after context cancellation")
+	}
+}
+
+func TestTransmitterSink_WriteErrorWithNilDeviceManagerDoesNotPanic(t *testing.T) {
+	writer := &mockWriter{
+		linkType: layers.LinkTypeEthernet,
+		writeErr: errors.New("device not configured"),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // ensure reconnectLoop exits immediately
+
+	s := &TransmitterSink{
+		dm:     nil,
+		Writer: writer,
+		Iname:  "eth0",
+		ctx:    ctx,
+		cancel: cancel,
+	}
+
+	pkt := &proxy.Packet{Raw: []byte("payload")}
+	if err := s.Write(pkt); err != nil {
+		t.Fatalf("Write should not return error: %v", err)
 	}
 }


### PR DESCRIPTION
Previous versions of udp-proxy-2020 would crash when the VPN tunnel restarted.  We now gracefully handle this situation.

Fixes: #224